### PR TITLE
Updates readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,14 +6,14 @@
 
 ## Intro
 When you have a lots of values changing over the time in a planning, it become difficult to deal with it day per day. The solution is to group the same values and merge period.
-On way is having the temporary (type containing value on a period) everywhere but: you have the domain complexity everywhere and if you have to compose another domain you will have more wrapped types.
+One way is having the temporary (type containing value on a period) everywhere but: you have the domain complexity everywhere and if you have to compose another domain you will have more wrapped types.
 
-To simplify and compose functionalities, Outatime give an applicative functor approach. 
+To simplify and compose functionalities, Outatime provides an applicative functor approach. 
 Instead of having the wrapped type everywhere, a function containing all values as parameter is binded to values changing over the time.
 
 ## How it works
 By using merge function, intersection period, and finding the largest period for missing values, a function is applied each time you give the temporaries. 
-Each time the value is the function applied (given a function with n parameter, expect a function with n-1 parameter).
+Each time, the value is the function applied (given a function with n parameter, expect a function with n-1 parameter).
 
 ## Samples
 ```fsharp


### PR DESCRIPTION
Fixes a typo in README.md.

Changes "give" to "provides" to improve sentence structure.

Adds a comma to provide clarity for how Outatime uses "apply."